### PR TITLE
feature: publish as stack name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ This image has to be run as a sidekick of [rawmind/alpine-traefik][alpine-traefi
 
 Traefik labels, has to be created in your service, in order to get included in traefik dynamic config.
 
-- traefik.enable = <true | false> #Controls if you want to publish or not the service
-- traefik.domain	= <Domain name to route rule>
-- traefik.port = <port to expose throught traefik>
+- traefik.enable = *true | stack | false* #Controls if you want to publish or not the service
+  - true: the service will be published as *service_name.stack_name.traefik_domain*
+  - stack: the service will be published as *stack_name.domain*. WARNING: You can have collisions inside services within yout stack
+  - false: the service will not be published
+- traefik.domain	= *Domain name to route rule*
+- traefik.port = *port to expose throught traefik*
 
-[alpine-traefik]: https://github.com/rawmind0/alpine-traefik 
+[alpine-traefik]: https://github.com/rawmind0/alpine-traefik
 [rancher-tools]: https://github.com/rawmind0/rancher-tools

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -1,18 +1,36 @@
-[backends]{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
-  [backends.{{$service_name}}__{{$stack_name}}]
-    [backends.{{$service_name}}__{{$stack_name}}.circuitbreaker]
-      expression = "NetworkErrorRatio() > 0.5"
-    [backends.{{$service_name}}__{{$stack_name}}.LoadBalancer]
-      method = "drr" 
-      {{range $i2, $container := ls (printf "/stacks/%s/services/%s/containers" $stack_name $service_name)}}
-      {{$back_status := getv (printf "/stacks/%s/services/%s/containers/%s/health_state" $stack_name $service_name $container)}}{{if eq $back_status "healthy"}}
-    [backends.{{$service_name}}__{{$stack_name}}.servers.{{getv (printf "/stacks/%s/services/%s/containers/%s/name" $stack_name $service_name $container)}}]
-    url = "http://{{getv (printf "/stacks/%s/services/%s/containers/%s/primary_ip" $stack_name $service_name $container)}}:{{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}"
-    weight = 0{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
-[frontends]{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
-  [frontends.{{$service_name}}__{{$stack_name}}]
-  backend = "{{$service_name}}__{{$stack_name}}"
-  passHostHeader = true
-    [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
-    rule = "Host:{{$service_name}}.{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
-{{end}}{{end}}{{end}}{{end}}
+[backends]
+{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
+    [backends.{{$service_name}}__{{$stack_name}}]
+        [backends.{{$service_name}}__{{$stack_name}}.circuitbreaker]
+            expression = "NetworkErrorRatio() > 0.5"
+        [backends.{{$service_name}}__{{$stack_name}}.LoadBalancer]
+            method = "drr"{{range $i2, $container := ls (printf "/stacks/%s/services/%s/containers" $stack_name $service_name)}}{{$back_status := getv (printf "/stacks/%s/services/%s/containers/%s/health_state" $stack_name $service_name $container)}}{{if eq $back_status "healthy"}}
+        [backends.{{$service_name}}__{{$stack_name}}.servers.{{getv (printf "/stacks/%s/services/%s/containers/%s/name" $stack_name $service_name $container)}}]
+            url = "http://{{getv (printf "/stacks/%s/services/%s/containers/%s/primary_ip" $stack_name $service_name $container)}}:{{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}"
+            weight = 0{{end}}{{end}}
+{{else}}{{if eq $traefik_enable "stack"}}
+    [backends.{{$stack_name}}]
+        [backends.{{$stack_name}}.circuitbreaker]
+            expression = "NetworkErrorRatio() > 0.5"
+        [backends.{{$stack_name}}.LoadBalancer]
+            method = "drr"{{range $i2, $container := ls (printf "/stacks/%s/services/%s/containers" $stack_name $service_name)}}{{$back_status := getv (printf "/stacks/%s/services/%s/containers/%s/health_state" $stack_name $service_name $container)}}{{if eq $back_status "healthy"}}
+        [backends.{{$stack_name}}.servers.{{getv (printf "/stacks/%s/services/%s/containers/%s/name" $stack_name $service_name $container)}}]
+            url = "http://{{getv (printf "/stacks/%s/services/%s/containers/%s/primary_ip" $stack_name $service_name $container)}}:{{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}"
+            weight = 0{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}{{end}}
+
+[frontends]
+{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
+    [frontends.{{$service_name}}__{{$stack_name}}]
+        backend = "{{$service_name}}__{{$stack_name}}"
+        passHostHeader = true
+        [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
+            rule = "Host:{{$service_name}}.{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+{{else}}{{if eq $traefik_enable "stack"}}
+    [frontends.{{$stack_name}}]
+        backend = "{{$stack_name}}"
+        passHostHeader = true
+        [frontends.{{$stack_name}}.routes.service]
+            rule = "Host:{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+{{end}}{{end}}{{end}}{{end}}{{end}}
+


### PR DESCRIPTION
With this feature you can optionally publish your service with the stack_name.

This is useful when you have multiple stacks that exposes only one public service.

It is fully backwards compatible
