### PR TITLE
Add traefik.host label to allow multiple hostnames on services

### DIFF
--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -25,7 +25,7 @@
         backend = "{{$service_name}}__{{$stack_name}}"
         passHostHeader = true
         [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
-            rule = "Host:{{$service_name}}.{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+            rule = "Host:{{toLower($service_name)}}.{{toLower($stack_name)}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
 {{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
     [frontends.{{$service_name}}__{{$stack_name}}__host]
         backend = "{{$service_name}}__{{$stack_name}}"
@@ -38,7 +38,7 @@
         backend = "{{$stack_name}}"
         passHostHeader = true
         [frontends.{{$stack_name}}.routes.service]
-            rule = "Host:{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+            rule = "Host:{{toLower($stack_name)}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
 {{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
     [frontends.{{$stack_name}}__host]
         backend = "{{$stack_name}}"

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -27,7 +27,10 @@
         [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
             rule = "Host:{{$service_name}}.{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
 {{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
-        [frontends.{{$service_name}}__{{$stack_name}}.routes.host]
+    [frontends.{{$service_name}}__{{$stack_name}}__host]
+        backend = "{{$service_name}}__{{$stack_name}}"
+        passHostHeader = true
+        [frontends.{{$service_name}}__{{$stack_name}}__host.routes.host]
             rule = "Host:{{getv (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}"
 {{end}}
 {{else}}{{if eq $traefik_enable "stack"}}
@@ -37,7 +40,10 @@
         [frontends.{{$stack_name}}.routes.service]
             rule = "Host:{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
 {{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
-        [frontends.{{$stack_name}}.routes.host]
+    [frontends.{{$stack_name}}__host]
+        backend = "{{$stack_name}}"
+        passHostHeader = true
+        [frontends.{{$stack_name}}__host.routes.host]
             rule = "Host:{{getv (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}" 
 {{end}}
 {{end}}{{end}}{{end}}{{end}}{{end}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -25,7 +25,7 @@
         backend = "{{$service_name}}__{{$stack_name}}"
         passHostHeader = true
         [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
-            rule = "Host:{{toLower($service_name)}}.{{toLower($stack_name)}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+            rule = "Host:{{toLower $service_name }}.{{toLower $stack_name }}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
 {{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
     [frontends.{{$service_name}}__{{$stack_name}}__host]
         backend = "{{$service_name}}__{{$stack_name}}"
@@ -38,7 +38,7 @@
         backend = "{{$stack_name}}"
         passHostHeader = true
         [frontends.{{$stack_name}}.routes.service]
-            rule = "Host:{{toLower($stack_name)}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+            rule = "Host:{{toLower $stack_name }}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
 {{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
     [frontends.{{$stack_name}}__host]
         backend = "{{$stack_name}}"

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -26,11 +26,19 @@
         passHostHeader = true
         [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
             rule = "Host:{{$service_name}}.{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+{{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
+        [frontends.{{$service_name}}__{{$stack_name}}.routes.host]
+            rule = "Host:{{getv (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}"
+{{end}}
 {{else}}{{if eq $traefik_enable "stack"}}
     [frontends.{{$stack_name}}]
         backend = "{{$stack_name}}"
         passHostHeader = true
         [frontends.{{$stack_name}}.routes.service]
             rule = "Host:{{$stack_name}}.{{getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)}}"
+{{if exists (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}
+        [frontends.{{$stack_name}}.routes.host]
+            rule = "Host:{{getv (printf "/stacks/%s/services/%s/labels/traefik.host" $stack_name $service_name)}}" 
+{{end}}
 {{end}}{{end}}{{end}}{{end}}{{end}}
 


### PR DESCRIPTION
This allows a service to have label traefik.host=foo.example.com, and then the service will be available as http://foo.example.com/ as well as http://$service.$stack.$domain/.  The label can also take multiple entries comma separated.

This is for situations where you already have a common hostname over the service, or where you want to have a more user-friendly alias than the dynamically generate hostname.

Note that it uses multiple frontends to do this; ideally, it would be a separate route in the same frontend, but a bug in traefik (possibly fixed this past april?) prevents this from working if you have multiple Host rules in a single Frontend (I've tried it -- you just get 404 errors and never a match)
