### PR TITLE
ACME support

### DIFF
--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -32,3 +32,15 @@
         [frontends.{{$stack_name}}.routes.service]{{ $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1}}
           {{ $domain := split $domains "," }}rule = "Host:{{range $i, $v := $domain}}{{if $i}},{{end}}{{toLower $stack_name}}.{{$v}}{{end}}"
 {{end}}{{end}}{{end}}{{end}}{{end}}
+
+{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
+[[acme.domains]]
+    {{ $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1}}
+    {{ $domain := split $domains "," }}main = "{{toLower $service_name}}.{{toLower $stack_name}}.{{index $domain 0}}"
+    sans = [{{range $i, $v := $domain}}"{{if $i}},{{end}}{{toLower $service_name}}.{{toLower $stack_name}}.{{$v}}"{{end}}]
+{{else}}{{if eq $traefik_enable "stack"}}
+[[acme.domains]]
+    {{ $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1}}
+    {{ $domain := split $domains "," }}main = "{{toLower $stack_name}}.{{index $domain 0}}"
+    sans = [{{range $i, $v := $domain}}"{{if $i}},{{end}}{{toLower $stack_name}}.{{$v}}"{{end}}]
+{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -33,7 +33,7 @@
           {{ $domain := split $domains "," }}rule = "Host:{{range $i, $v := $domain}}{{if $i}},{{end}}{{toLower $stack_name}}.{{$v}}{{end}}"
 {{end}}{{end}}{{end}}{{end}}{{end}}
 
-{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
+{{range $s, $stack_name := ls "/stacks"}}{{range $i, $service_name := ls (printf "/stacks/%s/services" $stack_name)}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.acme" $stack_name $service_name)}}{{$traefik_acme := getv (printf "/stacks/%s/services/%s/labels/traefik.acme" $stack_name $service_name)}}{{if eq $traefik_acme "true"}}{{if exists (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{$traefik_enable := getv (printf "/stacks/%s/services/%s/labels/traefik.enable" $stack_name $service_name)}}{{if eq $traefik_enable "true"}}
 [[acme.domains]]
     {{ $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1}}
     {{ $domain := split $domains "," }}main = "{{toLower $service_name}}.{{toLower $stack_name}}.{{index $domain 0}}"
@@ -43,4 +43,4 @@
     {{ $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1}}
     {{ $domain := split $domains "," }}main = "{{toLower $stack_name}}.{{index $domain 0}}"
     sans = [{{range $i, $v := $domain}}"{{if $i}},{{end}}{{toLower $stack_name}}.{{$v}}"{{end}}]
-{{end}}{{end}}{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}


### PR DESCRIPTION
This enables ACME support for Traefik, generating rules.toml accordingly. There is a corresponding PR for alpine-traefik.
