### PR TITLE
Supplemental FQDNs

### DIFF
--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -78,6 +78,13 @@
               {{- end -}}
             {{- end -}}
           {{- end -}}
+          {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.supplemental_fqdns" $stack_name $service_name) -}}
+            {{- $fqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.supplemental_fqdns" $stack_name $service_name)) " " "" -1 -}}
+            {{- $fqdnlist := split $fqdns ","}}
+            {{- range $i, $fqdn := $fqdnlist -}}
+              ,{{- toLower $fqdn -}}
+            {{- end -}}
+          {{- end -}}
           ;
         {{- end -}}
         {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.path" $stack_name $service_name) -}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -17,9 +17,9 @@
     [backends.{{$service_name}}__{{$stack_name}}.servers.{{getv (printf "/stacks/%s/services/%s/containers/%s/name" $stack_name $service_name $container)}}]
       url = "http://{{getv (printf "/stacks/%s/services/%s/containers/%s/primary_ip" $stack_name $service_name $container) -}}:
               {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name) -}}
-              {{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}
+                {{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}
               {{- else -}}
-              80
+                80
               {{- end}}"
       weight = 0
             {{- end -}}
@@ -30,9 +30,9 @@
     [backends.{{$service_name}}__{{$stack_name}}.servers.{{$stack_name}}_{{$service_name}}_external_ip_{{$external_ip}}]
       url = "http://{{getv (printf "/stacks/%s/services/%s/external_ips/%s" $stack_name $service_name $external_ip) -}}:
             {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name) -}}
-            {{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}
+              {{getv (printf "/stacks/%s/services/%s/labels/traefik.port" $stack_name $service_name)}}
             {{- else -}}
-            80
+              80
             {{- end}}"
       weight = 0
           {{- end -}}
@@ -52,7 +52,7 @@
     backend = "{{$service_name}}__{{$stack_name}}"
     passHostHeader = true
     priority =  {{ if exists (printf "/stacks/%s/services/%s/labels/traefik.priority" $stack_name $service_name) -}}
-                {{  getv (printf "/stacks/%s/services/%s/labels/traefik.priority" $stack_name $service_name)  }}
+                  {{  getv (printf "/stacks/%s/services/%s/labels/traefik.priority" $stack_name $service_name)  }}
                 {{ else -}}
                   5
                 {{- end}}


### PR DESCRIPTION
Adds a new `traefik.supplemental_fqdns`, a comma-separated list of FQDNs that should be copied verbatim into the `Host` rule.  This allows a user to specify the exact FQDN they want for any particular stack without altering behavior of existing labels.

My first time working with Traefik or Go, input appreciated.