### PR TITLE
Added the option to use HostRegexp directive in labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Traefik labels, has to be created in your service or externalService, in order t
 - traefik.priority = <priority>     	  	# Override for frontend priority. 5 by default
 - traefik.alias = < alias >					# Alternate names to route rule. Multiple values separated by ",". WARNING: You could have collisions BE CAREFULL
 - traefik.domain = < domain.name >			# Domain names to route rules. Multiple domains separated by ","
+- traefik.domain.regexp = < domain.regexp > # Domain name regexp rule. Multiple domains separated by ","
 - traefik.port = <port>						# port to expose throught traefik
 - traefik.acme = < true | false >			# Enable/disable ACME traefik feature
 - traefik.path = < path >		    		# Path rule. Multiple values separated by ","

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -58,6 +58,15 @@
                 {{- end}}
     [frontends.{{$service_name}}__{{$stack_name}}.routes.service]
       rule = "
+        {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.domain.regexp" $stack_name $service_name) -}}HostRegexp:
+          {{- $regexpses := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain.regexp" $stack_name $service_name)) " " "" -1 -}}
+          {{- $regexp := split $regexpses ","}}
+            {{- range $i, $r := $regexp -}}
+              {{- if $i -}},{{- end -}}
+              {{- if not (eq $r "") -}}{{- toLower $r -}}{{- end -}}
+            {{- end -}}
+          ;
+        {{- end -}}
         {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name) -}}Host:
           {{- $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1 -}}
           {{- $domain := split $domains ","}}


### PR DESCRIPTION
Added the ability add a label `traefik.domain.regexp` that results in a `HostRegexp` directive in the Traefik rules. The configuration is inclusive meaning that it can be used together with all the other directives.

_BONUS:_ Updated the README to include the label option