### PR TITLE
Add two features to traefik rules (sticky sessions and more Host: options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Traefik labels, has to be created in your service or externalService, in order t
   - false: the service will not be published
 - traefik.priority = <priority>     	  	# Override for frontend priority. 5 by default
 - traefik.protocol = < http | https	>		# Override the default http protocol
+- traefik.sticky = < true | false	>		# Enable/disable sticky sessions to the backend
 - traefik.alias = < alias >					# Alternate names to route rule. Multiple values separated by ",". WARNING: You could have collisions BE CAREFULL
 - traefik.domain = < domain.name >			# Domain names to route rules. Multiple domains separated by ","
 - traefik.domain.regexp = < domain.regexp > # Domain name regexp rule. Multiple domains separated by ","

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Traefik labels, has to be created in your service or externalService, in order t
 - traefik.priority = <priority>     	  	# Override for frontend priority. 5 by default
 - traefik.protocol = < http | https	>		# Override the default http protocol
 - traefik.sticky = < true | false	>		# Enable/disable sticky sessions to the backend
-- traefik.alias = < alias >					# Alternate names to route rule. Multiple values separated by ",". WARNING: You could have collisions BE CAREFULL
+- traefik.alias = < alias >					# Alternate names to route rule. Multiple values separated by ",". traefik.domain is appended. WARNING: You could have collisions BE CAREFULL
+- traefik.alias.fqdn = < alias fqdn >					# Alternate names to route rule. Multiple values separated by ",". traefik.domain must be defined but is not appended here.
 - traefik.domain = < domain.name >			# Domain names to route rules. Multiple domains separated by ","
 - traefik.domain.regexp = < domain.regexp > # Domain name regexp rule. Multiple domains separated by ","
 - traefik.port = <port>						# port to expose throught traefik

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -10,7 +10,7 @@
     [backends.{{$service_name}}__{{$stack_name}}.LoadBalancer]
       method = "drr"
         {{- $traefik_sticky := getv (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
-        {{- if eq $traefik_sticky "true" -}}
+        {{- if eq $traefik_sticky "true"}}
       sticky = true
         {{- end -}}
         {{- $service_kind := getv (printf "/stacks/%s/services/%s/kind" $stack_name $service_name) -}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -9,9 +9,11 @@
       expression = "NetworkErrorRatio() > 0.5"
     [backends.{{$service_name}}__{{$stack_name}}.LoadBalancer]
       method = "drr"
-        {{- $traefik_sticky := getv (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
-        {{- if eq $traefik_sticky "true"}}
+        {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
+          {{- $traefik_sticky := getv (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
+          {{- if eq $traefik_sticky "true"}}
       sticky = true
+          {{- end -}}
         {{- end -}}
         {{- $service_kind := getv (printf "/stacks/%s/services/%s/kind" $stack_name $service_name) -}}
         {{- if eq $service_kind "service" -}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -218,8 +218,7 @@
                         {{- $afqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name)) " " "" -1 -}}
                         {{- $afqdn := split $afqdns ","}}
                         {{- range $i2, $af := $afqdn -}}
-                          {{- if or ($i) ($i2) -}},{{- end -}}
-                          {{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
+                          ,{{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
                         {{- end -}}
                       {{- end -}}
                       {{- if (eq (len $domain) 1) -}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -9,6 +9,10 @@
       expression = "NetworkErrorRatio() > 0.5"
     [backends.{{$service_name}}__{{$stack_name}}.LoadBalancer]
       method = "drr"
+      {{- $traefik_sticky := getv (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
+      {{- if eq $traefik_sticky "true"}}
+      sticky = true
+      {{- end -}}
         {{- $service_kind := getv (printf "/stacks/%s/services/%s/kind" $stack_name $service_name) -}}
         {{- if eq $service_kind "service" -}}
           {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.protocol" $stack_name $service_name) -}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -129,12 +129,12 @@
                 ,{{- if not (eq $a "") -}}{{- toLower $a -}}.{{- end -}}{{- $v -}}
               {{- end -}}
             {{- end -}}
-            {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name) -}}
-              {{- $afqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name)) " " "" -1 -}}
-              {{- $afqdn := split $afqdns ","}}
-              {{- range $i2, $af := $afqdn -}}
-                ,{{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
-              {{- end -}}
+          {{- end -}}
+          {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name) -}}
+            {{- $afqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name)) " " "" -1 -}}
+            {{- $afqdn := split $afqdns ","}}
+            {{- range $i2, $af := $afqdn -}}
+              ,{{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
             {{- end -}}
           {{- end -}}
           ;

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -129,6 +129,13 @@
                 ,{{- if not (eq $a "") -}}{{- toLower $a -}}.{{- end -}}{{- $v -}}
               {{- end -}}
             {{- end -}}
+            {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name) -}}
+              {{- $afqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name)) " " "" -1 -}}
+              {{- $afqdn := split $afqdns ","}}
+              {{- range $i2, $af := $afqdn -}}
+                ,{{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
+              {{- end -}}
+            {{- end -}}
           {{- end -}}
           ;
         {{- end -}}
@@ -203,17 +210,36 @@
                     {{- $alias := split $aliases ","}}
                     {{- if or (gt (len $domain) 1) (len $alias)}}
   sans = ["
-                      {{- range $i2 , $a:= $alias -}}
+                      {{- range $i2, $a := $alias -}}
                         {{- if or ($i) ($i2) -}},{{- end -}}
                         {{- if not (eq $a "") -}}{{- toLower $a -}}.{{- end -}}{{- $v -}}
+                      {{- end -}}
+                      {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name) -}}
+                        {{- $afqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name)) " " "" -1 -}}
+                        {{- $afqdn := split $afqdns ","}}
+                        {{- range $i2, $af := $afqdn -}}
+                          {{- if or ($i) ($i2) -}},{{- end -}}
+                          {{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
+                        {{- end -}}
                       {{- end -}}
                       {{- if (eq (len $domain) 1) -}}
           "]
                       {{end -}}
                     {{- end -}}
                   {{- else -}}
-                    {{- if gt (len $domain) 1}}
+                    {{- if or (gt (len $domain) 1) (exists (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name))}}
   sans = ["
+                      {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name) -}}
+                        {{- $afqdns := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.alias.fqdn" $stack_name $service_name)) " " "" -1 -}}
+                        {{- $afqdn := split $afqdns ","}}
+                        {{- range $i2, $af := $afqdn -}}
+                          {{- if or ($i) ($i2) -}},{{- end -}}
+                          {{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
+                        {{- end -}}
+                      {{- end -}}
+                      {{- if (eq (len $domain) 1) -}}
+          "]
+                      {{end -}}
                     {{- end -}}
                   {{- end -}}
                 {{- else -}}

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -236,6 +236,7 @@
                           {{- if or ($i) ($i2) -}},{{- end -}}
                           {{- if not (eq $af "") -}}{{- toLower $af -}}{{- end -}}
                         {{- end -}}
+                        {{- if (gt (len $domain) 1) -}},{{- end -}}
                       {{- end -}}
                       {{- if (eq (len $domain) 1) -}}
           "]

--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -9,10 +9,10 @@
       expression = "NetworkErrorRatio() > 0.5"
     [backends.{{$service_name}}__{{$stack_name}}.LoadBalancer]
       method = "drr"
-      {{- $traefik_sticky := getv (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
-      {{- if eq $traefik_sticky "true"}}
+        {{- $traefik_sticky := getv (printf "/stacks/%s/services/%s/labels/traefik.sticky" $stack_name $service_name) -}}
+        {{- if eq $traefik_sticky "true" -}}
       sticky = true
-      {{- end -}}
+        {{- end -}}
         {{- $service_kind := getv (printf "/stacks/%s/services/%s/kind" $stack_name $service_name) -}}
         {{- if eq $service_kind "service" -}}
           {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.protocol" $stack_name $service_name) -}}


### PR DESCRIPTION
This PR adds two features I found useful.

The first feature it adds is support of sticky sessions in traefik.  This is enabled by the label "traefik.sticky=true".  This is useful for backends which do not natively support clients bouncing between them.

The second feature is the label "traefik.alias.fqdn".  I found that "traefik.alias" appends "traefik.domain" to it.  While this is normally okay, I found it difficult to match all of the available hostnames my frontends could use.

traefik.domain.regexp solves this sort of, except regexp can't be used for ACME certs.  "traefik.alias.fqdn" still requires traefik.domain to be defined as this would be used for the main FQDN in a cert, but the aliases can be added as Subject Alternative Names.

Let me know what questions you have :)