### PR TITLE
[FIX] Join domain regexp with comma

### DIFF
--- a/root/opt/tools/confd/etc/templates/rules.toml.tmpl
+++ b/root/opt/tools/confd/etc/templates/rules.toml.tmpl
@@ -110,7 +110,7 @@
               {{- if $i -}},{{- end -}}
               {{- if not (eq $r "") -}}{{- toLower $r -}}{{- end -}}
             {{- end -}}
-          ;
+          ,
         {{- end -}}
         {{- if exists (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name) -}}Host:
           {{- $domains := replace (getv (printf "/stacks/%s/services/%s/labels/traefik.domain" $stack_name $service_name)) " " "" -1 -}}


### PR DESCRIPTION
* A comma should be used when a domain regexp is in play so that it can be selected conditionally

Without this, the regex is pretty much pointless - because it would also need to match the explicit host rules. This was explained to me in https://github.com/containous/traefik/issues/1897 and is corroborated in the [docs](https://docs.traefik.io/basics/#matchers). 

Applying this change to my Traefik container fixed the rule